### PR TITLE
Add a new false negative test case

### DIFF
--- a/TNT.Tests.CSharp/TranslateableTextClass.cs
+++ b/TNT.Tests.CSharp/TranslateableTextClass.cs
@@ -15,12 +15,24 @@ namespace TNT.Tests.CSharp
         public static readonly string TranslateMe = "originalCG".t();
     }
 
-    public class ExtractionError
+    public class NonEmptyStringWithConcatenationCantBeExtracted
     {
         public static readonly string TranslateMe = mkStr();
 
         static string mkStr()
         {
+            return ("xx" + new Random().Next()).t();
+        }
+    }
+
+    public class EmptyStringWithConcatenation
+    {
+        public static readonly string TranslateMe = mkStr();
+
+        static string mkStr()
+        {
+            // note: this extraction did not work before an update to a more recent (3.0 or 3.1) dotnet core version.
+            // I am not sure if we even want to extract empty strings anyway. But this works now.
             return ("" + new Random().Next()).t();
         }
     }

--- a/TNT.Tests/Extraction.fs
+++ b/TNT.Tests/Extraction.fs
@@ -33,6 +33,7 @@ let ``extract from CSharp``() =
     strings 
     |> OriginalStrings.strings 
     |> should equal [
+        "", [ LogicalContext "TNT.Tests.CSharp.EmptyStringWithConcatenation" ]
         "Formattable {0}", [ LogicalContext "TNT.Tests.CSharp.FormattableString" ]
         "explicit", [ LogicalContext "TNT.Tests.CSharp.Explicit" ]
         "explicit2", [ LogicalContext "TNT.Tests.CSharp.Explicit" ]


### PR DESCRIPTION
For some reason an extraction of the expression `("" + Random().next()).t()` succeeds now, probably because of some underlying changes related to the generation of IL, to create a false negative test case another a new one has to built.