### PR TITLE
Support tnt-cli on platforms without dotnet 2 installed

### DIFF
--- a/tnt/tnt.fsproj
+++ b/tnt/tnt.fsproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageId>tnt-cli</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Title>The .NET Translation Tool</Title>
     <Authors>Armin Sander</Authors>
     <Description>Command line tool for organizing translation strings extracted from .NET assemblies. Supports Excel, XLIFF roundtrips and machine translations.</Description>
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/pragmatrix/tnt.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
If only dotnet 3 is installed, tnt will fail with the following error message:

```bash
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - The following frameworks were found:
      3.1.0 at [/Users/runner/hostedtoolcache/dotnet/shared/Microsoft.NETCore.App]
```

This PR fixes that by allowing tnt to be run on major version updates of dotnet core.