### PR TITLE
Support Google Translate V3 batching and error reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.paket/
-/paket-files/
 /.vs/
+/.fake/
+/.ionide/
+/paket-files/
 bin/
 obj/
 /*.ncrunchsolution.user

--- a/TNT.Tests/Translation.fs
+++ b/TNT.Tests/Translation.fs
@@ -83,3 +83,51 @@ module Counters =
                 Notes = [ "Note 1"; "Note 2" ]
             } ]
         }
+
+module MachineTranslations = 
+    open TNT.Library.MachineTranslation
+
+    [<Fact>]
+    let ``empty strings creates empty batches``() = 
+        []
+        |> Google.createBatches 100
+        |> should equal []
+
+        []
+        |> Google.createBatches 1
+        |> should equal []
+
+    [<Fact>]
+    let ``one string one batch``() =
+        ["Hello"]
+        |> Google.createBatches 100
+        |> should equal [["Hello"]]
+
+    [<Fact>]
+    let ``two single that exceed the max code points``() =
+        ["Hello"; "_ello"]
+        |> Google.createBatches 4
+        |> should equal [["Hello"]; ["_ello"]]
+
+        ["Hello"; "_ello"]
+        |> Google.createBatches 1
+        |> should equal [["Hello"]; ["_ello"]]
+
+    [<Fact>]
+    let ``two single that are equal to the max code points``() =
+        ["Hello"; "_ello"]
+        |> Google.createBatches 5
+        |> should equal [["Hello"]; ["_ello"]]
+
+    [<Fact>]
+    let ``two single that are shorter``() =
+        ["Hello"; "_ello"]
+        |> Google.createBatches 6
+        |> should equal [["Hello"; "_ello"]]
+
+    [<Fact>]
+    let ``four that need to split at the middle``() =
+        ["0"; "1"; "2"; "3"]
+        |> Google.createBatches 2
+        |> should equal [["0"; "1"]; ["2"; "3"]]
+


### PR DESCRIPTION
Because Google imposes limits on the translation API, we need to translate the string in batches (see #90 and #91). This PR takes Google's recommended 5000 code points into account and also supports partial translations, which make sense when request quotas would be exceeded.